### PR TITLE
Escape Angular interpolation syntax by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,16 @@ Jade (`.jade`) files are processed. For Dart source files, code blocks in API co
 ```
 Usage: code_excerpt_updater [OPTIONS] file_or_directory...
 
--p, --fragment-dir-path    Path to the directory containing code fragment files.
-                           (Default is current working directory.)
+-p, --fragment-dir-path               Path to the directory containing code fragment files
+                                      (defaults to "", that is, the current working directory)
 
--h, --help                 Show command help.
--i, --indentation          Default code indentation to be used for code inside code blocks.
--w, --write-in-place             Write updates to files in-place.
+-h, --help                            Show command help
+-i, --indentation                     Default number of spaces to use as indentation for code inside code blocks
+                                      (defaults to "0")
+
+-w, --write-in-place                  Write updates to files in-place
+    --[no-]escape-ng-interpolation    Escape Angular interpolation syntax {{...}} as {!{...}!}
+                                      (defaults to on)
 ```
 
 For example, you can run the updater over 

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -74,6 +74,7 @@ void main() {
   group('Basic:', testsFromDefaultDir);
   group('Set path:', testSetPath);
   group('Default indentation:', testDefaultIndentation);
+  group('Disable escape ng interpolation:', testNoEscapeNgInterpolation);
 }
 
 void testsFromDefaultDir() {
@@ -101,9 +102,10 @@ void testsFromDefaultDir() {
 
   group('Code updates;', () {
     final _testFileNames = [
-      'no_comment_prefix.md',
       'basic_no_region.dart',
       'basic_with_region.dart',
+      'escape_ng_interpolation.md',
+      'no_comment_prefix.md',
     ];
 
     _testFileNames.forEach(_stdFileTest);
@@ -136,4 +138,13 @@ void testDefaultIndentation() {
   });
 
   _stdFileTest('basic_with_region.jade');
+}
+
+void testNoEscapeNgInterpolation() {
+  setUp(() {
+    updater =
+        new Updater(p.join(_testDir, 'frag'), escapeNgInterpolation: false);
+  });
+
+  _stdFileTest('no_escape_ng_interpolation.md');
 }

--- a/test_data/expected/escape_ng_interpolation.md
+++ b/test_data/expected/escape_ng_interpolation.md
@@ -1,0 +1,6 @@
+<?code-excerpt "ng_interpolation.html"?>
+```
+<div>
+  <h1>Hello {!{name}!}!</h1>
+</div>
+```

--- a/test_data/expected/no_escape_ng_interpolation.md
+++ b/test_data/expected/no_escape_ng_interpolation.md
@@ -1,0 +1,6 @@
+<?code-excerpt "ng_interpolation.html"?>
+```
+<div>
+  <h1>Hello {{name}}!</h1>
+</div>
+```

--- a/test_data/frag/ng_interpolation.html.txt
+++ b/test_data/frag/ng_interpolation.html.txt
@@ -1,0 +1,3 @@
+<div>
+  <h1>Hello {{name}}!</h1>
+</div>

--- a/test_data/src/escape_ng_interpolation.md
+++ b/test_data/src/escape_ng_interpolation.md
@@ -1,0 +1,3 @@
+<?code-excerpt "ng_interpolation.html"?>
+```
+```

--- a/test_data/src/no_change/no_path.md
+++ b/test_data/src/no_change/no_path.md
@@ -2,7 +2,7 @@ Test: code-excerpt instruction w/o a path; i.e., which need not be updated:
 
 <?code-excerpt title="abc"?>
 ```html
-<h1>Hello World!</h1>
+<h1>Hello {{name}}!</h1>
 ```
 
 <?code-excerpt?>

--- a/test_data/src/no_escape_ng_interpolation.md
+++ b/test_data/src/no_escape_ng_interpolation.md
@@ -1,0 +1,3 @@
+<?code-excerpt "ng_interpolation.html"?>
+```
+```


### PR DESCRIPTION
The Liquid templating language uses the same syntax "{{...}}" as Angular. This PR adds support for escaping this syntax to "{!{...}!}" by default.