### PR TITLE
Respect instruction argument order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.18.0
+
+- BREAKING CHANGE: Respect code-excerpt instruction argument order. 
+
 ## 0.17.1, 0.17.2
 
 - Internal refactoring: e.g., use `Matcher` rather than `RegExp` as diff argument types.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Recognized arguments are:
   The language is the code-block language, if specified, otherwise it is taken to be the excerpt path extension.
 
 Notes:
+- Arguments are processed in the order they appear. This is significant for arguments like
+  `replace`, `remove`, etc.
 - The `<?code-excerpt?>` instruction can optionally be preceded by an single-line comment
   token. Namely either `//` or `///`.
 - Path, and arguments if given, must be enclosed in double quotes.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_excerpt_updater
-version: 0.17.2
+version: 0.18.0
 
 description: Updates code excerpts inside markdown code blocks.
 

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -146,6 +146,7 @@ void testsFromDefaultDir() {
 
   group('Code updates;', () {
     final _testFileNames = [
+      'arg-order.md',
       'basic_no_region.dart',
       'basic_with_empty_region.md',
       'basic_with_region.dart',

--- a/test_data/expected/arg-order.md
+++ b/test_data/expected/arg-order.md
@@ -1,0 +1,10 @@
+## Test arg order
+
+<?code-excerpt "basic.dart" replace="/hello/bonjour/g" retain="bonjour"?>
+```
+var greeting = 'bonjour';
+```
+
+<?code-excerpt "basic.dart" retain="bonjour" replace="/hello/bonjour/g"?>
+```
+```

--- a/test_data/src/arg-order.md
+++ b/test_data/src/arg-order.md
@@ -1,0 +1,9 @@
+## Test arg order
+
+<?code-excerpt "basic.dart" replace="/hello/bonjour/g" retain="bonjour"?>
+```
+```
+
+<?code-excerpt "basic.dart" retain="bonjour" replace="/hello/bonjour/g"?>
+```
+```


### PR DESCRIPTION
This is a BREAKING CHANGE for instructions that use two or more of `remove`, `replace` and `retain`.