### PR TITLE
Support `from` and `to` as a (non-diff) code-excerpt args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.18.1
+
+- Support `from` and `to` for non-diff code-excerpt instructions.
+
 ## 0.18.0
 
 - BREAKING CHANGE: Respect code-excerpt instruction argument order. 

--- a/lib/src/code_excerpt_updater.dart
+++ b/lib/src/code_excerpt_updater.dart
@@ -277,12 +277,16 @@ class Updater {
 
   CodeTransformer _argToTransformer(String arg, String value) {
     switch (arg) {
+      case 'from':
+        return fromCodeTransformer(value);
       case 'remove':
         return removeCodeTransformer(value);
       case 'replace':
         return _replace.codeTransformer(value);
       case 'retain':
         return retainCodeTransformer(value);
+      case 'to':
+        return toCodeTransformer(value);
       default:
         return null;
     }

--- a/lib/src/code_transformer/core.dart
+++ b/lib/src/code_transformer/core.dart
@@ -9,7 +9,7 @@ typedef CodeTransformer = String Function(String code);
 CodeTransformer compose(CodeTransformer f, CodeTransformer g) =>
     f == null ? g : g == null ? f : (String s) => g(f(s));
 
-CodeTransformer lineMatcherToCodeTransformer(Matcher p) => (String code) {
+CodeTransformer _retain(Matcher p) => (String code) {
       final lines = code.split(eol)..retainWhere(p);
       return lines.join(eol);
     };
@@ -19,13 +19,43 @@ CodeTransformer lineMatcherToCodeTransformer(Matcher p) => (String code) {
 //---
 
 @nullable
+CodeTransformer fromCodeTransformer(String arg) {
+  final matcher = patternArgToMatcher(arg, 'from');
+  if (matcher == null) return null;
+  return (String code) {
+    final lines = code.split(eol).skipWhile(not(matcher));
+    return lines.join(eol);
+  };
+}
+
+@nullable
 CodeTransformer removeCodeTransformer(String arg) {
   final matcher = patternArgToMatcher(arg, 'remove');
-  return matcher == null ? null : lineMatcherToCodeTransformer(not(matcher));
+  return matcher == null ? null : _retain(not(matcher));
 }
 
 @nullable
 CodeTransformer retainCodeTransformer(String arg) {
   final matcher = patternArgToMatcher(arg, 'retain');
-  return matcher == null ? null : lineMatcherToCodeTransformer(matcher);
+  return matcher == null ? null : _retain(matcher);
+}
+
+@nullable
+CodeTransformer toCodeTransformer(String arg) {
+  final matcher = patternArgToMatcher(arg, 'to');
+  if (matcher == null) return null;
+  return (String code) {
+    final lines = code.split(eol);
+    final i = _indexWhere(lines, matcher); // lines.indexWhere(matcher)
+    if (i < 0) return code;
+    return lines.take(i + 1).join(eol);
+  };
+}
+
+/// Patch: 1.24.3 doesn't have Iterable.indexWhere(). Drop this once we drop 1.x
+int _indexWhere(List<String> list, bool test(String s)) {
+  for (var i = 0; i < list.length; i++) {
+    if (test(list[i])) return i;
+  }
+  return -1;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_excerpt_updater
-version: 0.18.0
+version: 0.18.1
 
 description: Updates code excerpts inside markdown code blocks.
 

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -129,6 +129,7 @@ void testsFromDefaultDir() {
     final _testFileNames = [
       'basic_diff.dart',
       'basic_no_region.dart',
+      'basic_with_args.md',
       'basic_with_region.dart',
       'diff.md',
       'frag_not_found.dart',

--- a/test_data/src/no_change/basic_with_args.md
+++ b/test_data/src/no_change/basic_with_args.md
@@ -1,0 +1,49 @@
+## Test `from` arg
+
+<?code-excerpt "basic.dart" from="world"?>
+```dart
+var scope = 'world';
+
+void main() => print('$greeting $scope');
+```
+
+Pattern not in excerpt:
+
+<?code-excerpt "basic.dart" from="zzz"?>
+```dart
+```
+
+## Test `to` arg
+
+<?code-excerpt "basic.dart" to="world"?>
+```dart
+var greeting = 'hello';
+var scope = 'world';
+```
+
+Pattern matching last line of excerpt:
+
+<?code-excerpt "basic.dart" to="main"?>
+```dart
+var greeting = 'hello';
+var scope = 'world';
+
+void main() => print('$greeting $scope');
+```
+
+Pattern not in excerpt:
+
+<?code-excerpt "basic.dart" to="zzz"?>
+```dart
+var greeting = 'hello';
+var scope = 'world';
+
+void main() => print('$greeting $scope');
+```
+
+## Test `from` and `to`
+
+<?code-excerpt "basic.dart" from="world" to="world"?>
+```dart
+var scope = 'world';
+```


### PR DESCRIPTION
(Diffs already support `from` and `to`.)